### PR TITLE
redirect to /web/ with http 302 instead of 301

### DIFF
--- a/testapp/ez/server/servermain.go
+++ b/testapp/ez/server/servermain.go
@@ -128,7 +128,7 @@ func main() {
 
 	// Redirect the home page to /web/
 	r.GET("/", func(c *gin.Context) {
-		http.Redirect(c.Writer, c.Req, "/web/", http.StatusMovedPermanently)
+		http.Redirect(c.Writer, c.Req, "/web/", http.StatusFound)
 	})
 
 	//


### PR DESCRIPTION
The 301 redirect gets cached and then might screw with other projects running on localhost:3000
